### PR TITLE
URL Cleanup

### DIFF
--- a/core/src/test/resources/application-context.xml
+++ b/core/src/test/resources/application-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:plugin="http://www.springframework.org/schema/plugin"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/plugin http://www.springframework.org/schema/plugin/spring-plugin.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/plugin https://www.springframework.org/schema/plugin/spring-plugin.xsd">
 
 	<plugin:list id="foo" class="org.springframework.plugin.core.SamplePlugin" />
 	


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.springframework.org/schema/plugin/spring-plugin.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/plugin/spring-plugin.xsd ([https](https://www.springframework.org/schema/plugin/spring-plugin.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/plugin with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences