### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a
 copy of the source code corresponding to the binaries for such open source
 components and modifications thereto, if any, (the "Source Files"), by
-downloading the Source Files from http://www.springsource.org/download,
+downloading the Source Files from https://www.springsource.org/download,
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General

--- a/README.markdown
+++ b/README.markdown
@@ -138,8 +138,8 @@ Actually this already serves a lot of requirements we listed in [Section “Cont
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:plugin="http://www.springframework.org/schema/plugin"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/plugin http://www.springframework.org/schema/plugin/spring-plugin.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/plugin https://www.springframework.org/schema/plugin/spring-plugin.xsd">
 
   <import resource="classpath*:com/acme/**/plugins.xml" />
 
@@ -239,7 +239,7 @@ This configuration snippet will register a `OrderAwarePluginRegistry` for `MyPlu
 
 Declaring plugin beans sometimes it is necessary to preserve a certain order of plugins. Suppose you have a plugin host that already defines one plugin that shall always be executed after all plugins declared by extensions. Actually the Spring container typically returns beans in the order they were declared, so that you could import you wildcarded config files right before declaring the default plugin. Unfortunately the order of the beans is not contracted to be preserved for the Spring container. Thus we need a different solution.
 
-Spring provides two ways to order beans. First, you can implement `Ordered` interface and implement `getOrder` to place a plugin at a certain point in the list. Secondly you can user the `@Order` annotation. For more information on ordering capabilities of Spring see the [section on this topic in the Spring reference documentation](http://static.springsource.org/spring/docs/3.1.x/javadoc-api/org/springframework/core/Ordered.html).
+Spring provides two ways to order beans. First, you can implement `Ordered` interface and implement `getOrder` to place a plugin at a certain point in the list. Secondly you can user the `@Order` annotation. For more information on ordering capabilities of Spring see the [section on this topic in the Spring reference documentation](https://docs.spring.io/spring/docs/3.1.x/javadoc-api/org/springframework/core/Ordered.html).
 
 Using the Spring Plugin namespace you will get a `PluginRegistry` instance that is capable of preserving the order defined by the mentioned means. Using Spring Plugin
 programmatically use `OrderAwarePluginRegistry`.
@@ -277,7 +277,7 @@ The `MetadataProvider` interface is to be used in application plugin interfaces 
 
 OSGi
   
-  * Open Services Gateway Initiative - a fully fledged plugin runtime environment on top of the Java VM - [http://en.wikipedia.org/wiki/OSGi](http://en.wikipedia.org/wiki/OSGi).
+  * Open Services Gateway Initiative - a fully fledged plugin runtime environment on top of the Java VM - [https://en.wikipedia.org/wiki/OSGi](https://en.wikipedia.org/wiki/OSGi).
 
 ### X
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.springframework.org/schema/plugin/spring-plugin.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/plugin/spring-plugin.xsd ([https](https://www.springframework.org/schema/plugin/spring-plugin.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://static.springsource.org/spring/docs/3.1.x/javadoc-api/org/springframework/core/Ordered.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.1.x/javadoc-api/org/springframework/core/Ordered.html ([https](https://static.springsource.org/spring/docs/3.1.x/javadoc-api/org/springframework/core/Ordered.html) result 200).
* [ ] http://en.wikipedia.org/wiki/OSGi with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/OSGi ([https](https://en.wikipedia.org/wiki/OSGi) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 3 occurrences
* http://www.springframework.org/schema/plugin with 4 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences